### PR TITLE
Add Content-Disposition header to response

### DIFF
--- a/bin/markdown-server
+++ b/bin/markdown-server
@@ -52,6 +52,7 @@ class MarkdownizerFileHandler < HTTPServlet::FileHandler
     html.gsub!(/\P{ASCII}/){ "&##{$&.unpack('U').first};" }
 
     res['Content-Type'] = "text/html"
+    res['Content-Disposition'] = "inline"
     res.body = html
     res.content_length = html.length
 


### PR DESCRIPTION
I just added the content-disposition header so that the browser will parse the response instead of providing a download, e.g. when open a *.md file, closes #2.
